### PR TITLE
refactor: single line functions and change the password generator

### DIFF
--- a/tunder/lib/src/console/console_kernel.dart
+++ b/tunder/lib/src/console/console_kernel.dart
@@ -13,7 +13,7 @@ class ConsoleKernel implements ConsoleKernelContract {
 
   @override
   Future<int> handle(List<String> arguments) async {
-    var runner = CommandRunner('tunder', 'Tunder Framework $TunderVersion');
+    var runner = CommandRunner('tunder', 'Tunder Framework $tunderVersion');
 
     commands.forEach((command) => runner.addCommand(app.get(command)));
 

--- a/tunder/lib/src/core/application.dart
+++ b/tunder/lib/src/core/application.dart
@@ -10,21 +10,16 @@ class Application extends Container {
   static Application? _instance;
   static HttpServer? server;
 
-  factory Application({String? basePath, String? baseUrl}) {
-    if (_instance == null) {
-      _instance = create();
-      _instance!
-          .init(basePath: basePath ?? Directory.current.path, baseUrl: baseUrl);
-    }
-
-    return _instance!;
-  }
+  factory Application({String? basePath, String? baseUrl}) =>
+      _instance ??= create()
+        ..init(
+          basePath: basePath ?? Directory.current.path,
+          baseUrl: baseUrl,
+        );
 
   Application._();
 
-  static Application create() {
-    return Application._();
-  }
+  static Application create() => Application._();
 
   Future<HttpServer> serve({int port = 8000, DotEnv? dotenv}) async {
     dotenv ??= DotEnv();
@@ -48,12 +43,10 @@ class Application extends Container {
     return server!;
   }
 
-  void serveRequests(Stream<HttpRequest> requests) {
-    requests.listen((request) {
-      // print('[Request] ${request.method} ${request.uri.path}');
-      handleRequest(request);
-    });
-  }
+  serveRequests(Stream<HttpRequest> requests) => requests.listen((request) {
+        // print('[Request] ${request.method} ${request.uri.path}');
+        handleRequest(request);
+      });
 
   Future<void> handleRequest(HttpRequest baseRequest) async {
     HttpKernelContract kernel = get(HttpKernelContract);
@@ -66,13 +59,9 @@ class Application extends Container {
     _registerBaseSingletons();
   }
 
-  boot() {
-    _bootProviders();
-  }
+  boot() => _bootProviders();
 
-  flush() {
-    Application._instance = null;
-  }
+  flush() => Application._instance = null;
 
   _registerBaseSingletons() {
     singleton(Application, this);
@@ -99,7 +88,6 @@ class Application extends Container {
     bind('storage.path', "$basePath/storage");
   }
 
-  setBaseUrl(String? baseUrl) {
-    bind('app.url', baseUrl ?? 'http://localhost:8000');
-  }
+  setBaseUrl(String? baseUrl) =>
+      bind('app.url', baseUrl ?? 'http://localhost:8000');
 }

--- a/tunder/lib/src/core/binding_resolution_exception.dart
+++ b/tunder/lib/src/core/binding_resolution_exception.dart
@@ -1,1 +1,3 @@
-class BindingResolutionException implements Exception {}
+class BindingResolutionException implements Exception {
+  const BindingResolutionException();
+}

--- a/tunder/lib/src/core/container.dart
+++ b/tunder/lib/src/core/container.dart
@@ -5,9 +5,8 @@ import 'package:tunder/src/core/binding_resolution_exception.dart';
 class Container {
   final Map _bindingMap = {};
 
-  void bind(key, value, {bool shared = false}) {
-    _bindingMap[key] = {'value': value, 'shared': shared};
-  }
+  void bind(key, value, {bool shared = false}) =>
+      _bindingMap[key] = {'value': value, 'shared': shared};
 
   void singleton(key, value) => bind(key, value, shared: true);
 

--- a/tunder/lib/src/core/container.dart
+++ b/tunder/lib/src/core/container.dart
@@ -3,15 +3,13 @@ import 'dart:mirrors';
 import 'package:tunder/src/core/binding_resolution_exception.dart';
 
 class Container {
-  final Map _bindingMap = new Map();
+  final Map _bindingMap = {};
 
   void bind(key, value, {bool shared = false}) {
     _bindingMap[key] = {'value': value, 'shared': shared};
   }
 
-  void singleton(key, value) {
-    bind(key, value, shared: true);
-  }
+  void singleton(key, value) => bind(key, value, shared: true);
 
   T get<T>(key) {
     Map? binding = _bindingMap[key];
@@ -64,11 +62,10 @@ class Container {
     return instance.reflectee;
   }
 
-  MethodMirror? _getDefaultConstructor(ClassMirror mirror) {
-    return mirror.declarations.values
-            .where((m) => m is MethodMirror && m.isConstructor)
-            .firstWhere(
-                (constructor) => constructor.simpleName == mirror.simpleName)
-        as MethodMirror;
-  }
+  MethodMirror? _getDefaultConstructor(ClassMirror mirror) =>
+      mirror.declarations.values
+          .where((m) => m is MethodMirror && m.isConstructor)
+          .firstWhere(
+            (constructor) => constructor.simpleName == mirror.simpleName,
+          ) as MethodMirror;
 }

--- a/tunder/lib/src/core/extensions.dart
+++ b/tunder/lib/src/core/extensions.dart
@@ -35,8 +35,8 @@ extension TunderDurations on Duration {
 
 extension TunderString on String {
   String trimWith(String pattern) {
-    RegExp leading = RegExp('^[$pattern]*');
-    RegExp trailing = RegExp('/*[${pattern}]\$');
+    var leading = RegExp('^[$pattern]*');
+    var trailing = RegExp('/*[${pattern}]\$');
 
     return trim().replaceAll(leading, '').replaceAll(trailing, '').trim();
   }
@@ -98,9 +98,11 @@ extension TunderIterable<E> on Iterable<E> {
    */
   List flatten() {
     var list = [];
+
     for (var item in this) {
       item is Iterable ? list.addAll(item.flatten()) : list.add(item);
     }
+
     return list;
   }
 }

--- a/tunder/lib/src/core/pipeline.dart
+++ b/tunder/lib/src/core/pipeline.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:tunder/src/core/container.dart';
 
 class Pipeline {
-  late Container container;
-  var handlers = [];
-  var passable;
+  Container container;
+  List handlers = [];
+  dynamic passable;
 
   Pipeline(this.container);
 
@@ -35,7 +35,5 @@ class Pipeline {
     return pipeline(passable);
   }
 
-  FutureOr thenReturn() {
-    return then((passable) => passable);
-  }
+  FutureOr thenReturn() => then((passable) => passable);
 }

--- a/tunder/lib/src/database/db.dart
+++ b/tunder/lib/src/database/db.dart
@@ -10,37 +10,24 @@ class DB {
 
   static DatabaseConnection get newConnection {
     _connection = null;
-
     return connection;
   }
 
-  static Future<T> transaction<T>(Future<T> Function() function) async {
-    return connection.transaction(function);
-  }
+  static Future<T> transaction<T>(Future<T> Function() function) =>
+      connection.transaction(function);
 
-  static Future<int> execute(String query) async {
-    return connection.execute(query);
-  }
+  static Future<int> execute(String query) => connection.execute(query);
 
-  static Future<List<MappedRow>> query(String query) async {
-    return connection.query(query);
-  }
+  static Future<List<MappedRow>> query(String query) => connection.query(query);
 
-  static Future<bool> tableExists(String table) async {
-    return connection.tableExists(table);
-  }
+  static Future<bool> tableExists(String table) =>
+      connection.tableExists(table);
 
-  static Future begin() {
-    return connection.begin();
-  }
+  static Future begin() => connection.begin();
 
-  static Future commit() {
-    return connection.commit();
-  }
+  static Future commit() => connection.commit();
 
-  static Future rollback() {
-    return connection.rollback();
-  }
+  static Future rollback() => connection.rollback();
 }
 
 class DatabaseDriver {

--- a/tunder/lib/src/database/model.dart
+++ b/tunder/lib/src/database/model.dart
@@ -12,7 +12,7 @@ abstract class Model<T> {
   }
 
   dynamic _cast(PropertyReflection property, value) {
-    if (!(value is String)) return value;
+    if (value is! String) return value;
 
     if (property.type == int) return int.parse(value);
     if (property.type == DateTime) return DateTime.parse(value);
@@ -33,19 +33,15 @@ class InstanceReflection {
     instanceMirror = reflect(instance);
   }
 
-  List<PropertyReflection> get properties {
-    return classMirror.declarations.values
-        .where((declaration) => declaration is VariableMirror)
-        .map((declaration) =>
-            PropertyReflection(declaration as VariableMirror, this))
-        .toList();
-  }
+  List<PropertyReflection> get properties => classMirror.declarations.values
+      .where((declaration) => declaration is VariableMirror)
+      .map((declaration) =>
+          PropertyReflection(declaration as VariableMirror, this))
+      .toList();
 
-  void setProperty(String propertyName, dynamic value) {
-    properties
-        .firstWhere((property) => property.name == propertyName)
-        .set(value);
-  }
+  void setProperty(String propertyName, dynamic value) => properties
+      .firstWhere((property) => property.name == propertyName)
+      .set(value);
 }
 
 class PropertyReflection {
@@ -57,7 +53,5 @@ class PropertyReflection {
   String get name => mirror.simpleName.name;
   Type get type => mirror.type.reflectedType;
 
-  void set(dynamic value) {
-    instance?.instanceMirror.setField(Symbol(name), value);
-  }
+  set(dynamic value) => instance?.instanceMirror.setField(Symbol(name), value);
 }

--- a/tunder/lib/src/database/paginator.dart
+++ b/tunder/lib/src/database/paginator.dart
@@ -35,27 +35,23 @@ class Paginator<T> {
     );
   }
 
-  String toSql() {
-    return _paginated.toSql();
-  }
+  String toSql() => _paginated.toSql();
 
-  Query<T> get _paginated {
-    return query
-      ..offset = (page - 1) * perPage
-      ..limit = perPage;
-  }
+  Query<T> get _paginated => query
+    ..offset = (page - 1) * perPage
+    ..limit = perPage;
 }
 
 class Pagination<T> {
-  late final List<T> data;
-  late final int total;
-  late final int currentPage;
-  late final int perPage;
-  late final int lastPage;
-  late final int from;
-  late final int to;
+  final List<T> data;
+  final int total;
+  final int currentPage;
+  final int perPage;
+  final int lastPage;
+  final int from;
+  final int to;
 
-  Pagination({
+  const Pagination({
     required this.data,
     required this.total,
     required this.currentPage,

--- a/tunder/lib/src/database/postgres_connection.dart
+++ b/tunder/lib/src/database/postgres_connection.dart
@@ -2,18 +2,18 @@ import 'package:postgres/postgres.dart';
 import 'package:tunder/database.dart';
 
 class PostgresConnection implements DatabaseConnection {
-  late String host;
-  late int port;
-  late String database;
-  late String username;
-  late String password;
-  late Symbol driver;
+  String host;
+  int port;
+  String database;
+  String username;
+  String password;
+  Symbol driver;
   int _transactionLevel = 0;
   late PostgreSQLConnection _connection;
 
   String get url => 'postgres://$username:$password@$host:$port/$database';
   String get _name => 'sp_$_transactionLevel';
-  bool _isOpened = false;
+  bool _isOpen = false;
 
   PostgresConnection({
     this.host = 'localhost',
@@ -25,15 +25,13 @@ class PostgresConnection implements DatabaseConnection {
     _connection = _createNewConnection();
   }
 
-  PostgreSQLConnection _createNewConnection() {
-    return PostgreSQLConnection(
-      host,
-      port,
-      database,
-      username: username,
-      password: password,
-    );
-  }
+  PostgreSQLConnection _createNewConnection() => PostgreSQLConnection(
+        host,
+        port,
+        database,
+        username: username,
+        password: password,
+      );
 
   @override
   Future<int> execute(String query) async {
@@ -44,18 +42,18 @@ class PostgresConnection implements DatabaseConnection {
 
   @override
   Future<void> open() async {
-    if (_isOpened) return;
+    if (_isOpen) return;
     if (_connection.isClosed) _connection = _createNewConnection();
 
     await _connection.open();
 
-    _isOpened = true;
+    _isOpen = true;
   }
 
   @override
   void close() async {
     await _connection.close();
-    _isOpened = false;
+    _isOpen = false;
   }
 
   @override
@@ -91,11 +89,8 @@ class PostgresConnection implements DatabaseConnection {
     }
   }
 
-  List<MappedRow> _transformedRows(List rows) {
-    return rows.map((row) {
-      return row.values.single as MappedRow;
-    }).toList();
-  }
+  List<MappedRow> _transformedRows(List rows) =>
+      rows.map((row) => row.values.single as MappedRow).toList();
 
   @override
   Future begin() async {

--- a/tunder/lib/src/database/query.dart
+++ b/tunder/lib/src/database/query.dart
@@ -43,47 +43,34 @@ class Query<T> {
     return this;
   }
 
-  Future<List<T>> all() {
-    return get();
-  }
+  Future<List<T>> all() => get();
 
-  Future<T> findBy(column, value) async {
-    return this
-        .add(where(column).equals(value))
-        .first()
-        .catchError((e) => throw RecordNotFoundException());
-  }
+  Future<T> findBy(column, value) => this
+      .add(where(column).equals(value))
+      .first()
+      .catchError((e) => throw RecordNotFoundException());
 
-  Future<T?> findByOrNull(column, value) async {
-    return this.add(where(column).equals(value)).firstOrNull();
-  }
+  Future<T?> findByOrNull(column, value) =>
+      this.add(where(column).equals(value)).firstOrNull();
 
-  Future<T> find(value) {
-    return findBy('id', value);
-  }
+  Future<T> find(value) => findBy('id', value);
 
-  Future<T?> findOrNull(value) {
-    return findByOrNull('id', value);
-  }
+  Future<T?> findOrNull(value) => findByOrNull('id', value);
 
-  Future<T> first() {
-    return get().then((result) => result.first);
-  }
+  Future<T> first() => get().then((result) => result.first);
 
-  Future<T?> firstOrNull() {
-    return get().then((result) => result.isEmpty ? null : result.first);
-  }
+  Future<T?> firstOrNull() =>
+      get().then((result) => result.isEmpty ? null : result.first);
 
   Paginator<T> paginate({
     int page = 1,
     int perPage = 10,
-  }) {
-    return Paginator(
-      query: this,
-      page: page,
-      perPage: perPage,
-    );
-  }
+  }) =>
+      Paginator(
+        query: this,
+        page: page,
+        perPage: perPage,
+      );
 
   Query<T> orderBy(String column, [String direction = 'asc']) {
     _orderBy = 'ORDER BY "$column" ${direction.toUpperCase()}';
@@ -91,18 +78,14 @@ class Query<T> {
     return this;
   }
 
-  Future<List<T>> get() async {
-    return execute(toSql());
-  }
+  Future<List<T>> get() => execute(toSql());
 
   Future<int> count() async {
     var rows = await executeRaw(toSqlCount());
     return rows.first['total'];
   }
 
-  Future<List<MappedRow>> executeRaw(String sql) {
-    return _connection.query(sql);
-  }
+  Future<List<MappedRow>> executeRaw(String sql) => _connection.query(sql);
 
   Future<List<T>> execute(String sql) async {
     var results = await _connection.query(sql);
@@ -129,13 +112,9 @@ class Query<T> {
     return this;
   }
 
-  Query<T> and(Where where) {
-    return add(where..boolOperator = 'AND');
-  }
+  Query<T> and(Where where) => add(where..boolOperator = 'AND');
 
-  Query<T> or(Where where) {
-    return add(where..boolOperator = 'OR');
-  }
+  Query<T> or(Where where) => add(where..boolOperator = 'OR');
 
   Where where(String column) {
     var _where = Where(column);

--- a/tunder/lib/src/database/schema/index_schema.dart
+++ b/tunder/lib/src/database/schema/index_schema.dart
@@ -11,5 +11,5 @@ class IndexSchema {
     name,
   }) : this.name = name ?? '${table}_${column}_index';
 
-  toString() => name;
+  String toString() => name;
 }

--- a/tunder/lib/src/database/schema/postgres_schema_processor.dart
+++ b/tunder/lib/src/database/schema/postgres_schema_processor.dart
@@ -182,16 +182,13 @@ class PostgresSchemaProcessor
     }).flatten();
   }
 
-  List<String> getCreateIndexCommands(TableSchema table) {
-    return table.columns
-        .where((column) => column.addIndex != null)
-        .map((column) => _compileCreateIndex(column.addIndex!))
-        .toList();
-  }
+  List<String> getCreateIndexCommands(TableSchema table) => table.columns
+      .where((column) => column.addIndex != null)
+      .map((column) => _compileCreateIndex(column.addIndex!))
+      .toList();
 
-  List<String> getAddConstraintCommands(TableSchema table) {
-    return table.constraints.map(compileConstraintForUpdate).toList();
-  }
+  List<String> getAddConstraintCommands(TableSchema table) =>
+      table.constraints.map(compileConstraintForUpdate).toList();
 
   List<String> getRenameCommands(TableSchema table) {
     return table.renames.map((rename) {
@@ -350,9 +347,8 @@ class PostgresSchemaProcessor
     return indexes.map(_compileCreateIndex).join('; ');
   }
 
-  String compileIndexesForUpdate(TableSchema table) {
-    return table.indexes.map(_compileCreateIndex).join('; ');
-  }
+  String compileIndexesForUpdate(TableSchema table) =>
+      table.indexes.map(_compileCreateIndex).join('; ');
 
   String _compileCreateIndex(IndexSchema index) {
     var columns = ([index.column] + index.columns).map((column) => '"$column"');
@@ -441,7 +437,6 @@ class PostgresSchemaProcessor
   }
 
   @override
-  String renameSql(String from, String to) {
-    return 'alter table "$from" rename to "$to"';
-  }
+  String renameSql(String from, String to) =>
+      'alter table "$from" rename to "$to"';
 }

--- a/tunder/lib/src/database/schema/renames.dart
+++ b/tunder/lib/src/database/schema/renames.dart
@@ -2,17 +2,17 @@ class Rename {
   final String from;
   final String to;
 
-  Rename(this.from, this.to);
+  const Rename(this.from, this.to);
 }
 
 class RenameColumn extends Rename {
-  RenameColumn(String from, String to) : super(from, to);
+  const RenameColumn(String from, String to) : super(from, to);
 }
 
 class RenameIndex extends Rename {
-  RenameIndex(String from, String to) : super(from, to);
+  const RenameIndex(String from, String to) : super(from, to);
 }
 
 class RenamePrimary extends Rename {
-  RenamePrimary(String from, String to) : super(from, to);
+  const RenamePrimary(String from, String to) : super(from, to);
 }

--- a/tunder/lib/src/database/schema/schema_processor.dart
+++ b/tunder/lib/src/database/schema/schema_processor.dart
@@ -11,8 +11,9 @@ abstract class SchemaProcessor {
     switch (driver) {
       case DatabaseDriver.postgres:
         return PostgresSchemaProcessor();
+      default:
+        throw UnknownDatabaseDriverException(driver);
     }
-    throw UnknownDatabaseDriverException(driver);
   }
 
   String createSql(TableSchema table);

--- a/tunder/lib/src/database/schema/table_schema.dart
+++ b/tunder/lib/src/database/schema/table_schema.dart
@@ -72,9 +72,8 @@ class TableSchema {
   void softDeletes([String name = 'deleted_at']) =>
       _add(name, DataType.timestamp).nullable();
 
-  void index({required String column, String? name = null}) {
-    indexes.add(IndexSchema(column: column, table: this.name, name: name));
-  }
+  void index({required String column, String? name = null}) =>
+      indexes.add(IndexSchema(column: column, table: this.name, name: name));
 
   void unique(List<String> columns, {String? name}) => constraints
       .add(UniqueConstraint(columns: columns, table: this.name, name: name));
@@ -94,36 +93,47 @@ class TableSchema {
   }
 
   void check(String expression, {String? name}) => constraints.add(
-      CheckConstraint(expression: expression, table: this.name, name: name));
+        CheckConstraint(
+          expression: expression,
+          table: this.name,
+          name: name,
+        ),
+      );
 
-  void dropColumn(String column) {
-    droppings.add(ColumnSchema(column, DataType.string, this));
-  }
+  void dropColumn(String column) => droppings.add(
+        ColumnSchema(
+          column,
+          DataType.string,
+          this,
+        ),
+      );
 
-  void dropColumns(List<String> columns) {
-    columns.forEach((column) => dropColumn(column));
-  }
+  void dropColumns(List<String> columns) => columns.forEach(dropColumn);
 
   void dropTimestamps({
     String? createdColumn,
     String? updatedColumn,
     bool camelCase = false,
-  }) {
-    dropColumns([
-      createdColumn ?? (camelCase ? 'createdAt' : 'created_at'),
-      updatedColumn ?? (camelCase ? 'updatedAt' : 'updated_at'),
-    ]);
-  }
+  }) =>
+      dropColumns([
+        createdColumn ?? (camelCase ? 'createdAt' : 'created_at'),
+        updatedColumn ?? (camelCase ? 'updatedAt' : 'updated_at'),
+      ]);
 
   void dropSoftDeletes([String name = 'deleted_at']) => dropColumn(name);
 
-  void dropIndex({String? column, String? name}) {
-    droppings
-        .add(IndexSchema(column: column ?? '', table: this.name, name: name));
-  }
+  void dropIndex({String? column, String? name}) => droppings.add(
+        IndexSchema(
+          column: column ?? '',
+          table: this.name,
+          name: name,
+        ),
+      );
 
-  void dropIndexes(
-      {List<String> columns = const [], List<String> names = const []}) {
+  void dropIndexes({
+    List<String> columns = const [],
+    List<String> names = const [],
+  }) {
     columns.forEach((column) => dropIndex(column: column));
     names.forEach((name) => dropIndex(name: name));
   }
@@ -138,8 +148,10 @@ class TableSchema {
     ));
   }
 
-  void dropUniques(
-      {List<String> columns = const [], List<String> names = const []}) {
+  void dropUniques({
+    List<String> columns = const [],
+    List<String> names = const [],
+  }) {
     columns.forEach((column) => dropUnique(column: column));
     names.forEach((name) => dropUnique(name: name));
   }
@@ -147,27 +159,43 @@ class TableSchema {
   void dropPrimary({List<String>? columns, String? name}) {
     name ??= '${this.name}_${columns!.join('_')}_pkey';
     droppings.add(
-      PrimaryConstraint(table: this.name, name: name, columns: columns ?? []),
+      PrimaryConstraint(
+        table: this.name,
+        name: name,
+        columns: columns ?? [],
+      ),
     );
   }
 
-  void dropCheck(
-      {List<String> columns = const [], List<String> names = const []}) {
+  void dropCheck({
+    List<String> columns = const [],
+    List<String> names = const [],
+  }) {
     columns.forEach((column) {
       var name = '${this.name}_${column}_check';
       droppings.add(
-        CheckConstraint(expression: '', table: this.name, name: name),
+        CheckConstraint(
+          expression: '',
+          table: this.name,
+          name: name,
+        ),
       );
     });
     names.forEach((name) {
       droppings.add(
-        CheckConstraint(expression: '', table: this.name, name: name),
+        CheckConstraint(
+          expression: '',
+          table: this.name,
+          name: name,
+        ),
       );
     });
   }
 
-  void dropForeign(
-      {List<String> columns = const [], List<String> names = const []}) {
+  void dropForeign({
+    List<String> columns = const [],
+    List<String> names = const [],
+  }) {
     columns.forEach((column) {
       var name = '${this.name}_${column}_fkey';
       droppings.add(
@@ -189,17 +217,14 @@ class TableSchema {
     });
   }
 
-  void renameColumn(String from, String to) {
-    renames.add(RenameColumn(from, to));
-  }
+  void renameColumn(String from, String to) =>
+      renames.add(RenameColumn(from, to));
 
-  void renameIndex(String from, String to) {
-    renames.add(RenameIndex(from, to));
-  }
+  void renameIndex(String from, String to) =>
+      renames.add(RenameIndex(from, to));
 
-  void renamePrimary(String from, String to) {
-    renames.add(RenamePrimary(from, to));
-  }
+  void renamePrimary(String from, String to) =>
+      renames.add(RenamePrimary(from, to));
 
   ColumnSchema _add(String name, String datatype, [int length = 255]) {
     var column = ColumnSchema(name, datatype, this, length);

--- a/tunder/lib/src/database/where.dart
+++ b/tunder/lib/src/database/where.dart
@@ -8,13 +8,19 @@ class Where {
 
   Where(this.column, {this.boolOperator = 'AND'});
 
-  Where get and {
-    return add(Where(this.column, boolOperator: 'AND'));
-  }
+  Where get and => add(
+        Where(
+          this.column,
+          boolOperator: 'AND',
+        ),
+      );
 
-  Where get or {
-    return add(Where(this.column, boolOperator: 'OR'));
-  }
+  Where get or => add(
+        Where(
+          this.column,
+          boolOperator: 'OR',
+        ),
+      );
 
   Where add(Where where) {
     _wheres.add(where);
@@ -34,9 +40,7 @@ class Where {
     return this;
   }
 
-  Where notEqual(value) {
-    return different(value);
-  }
+  Where notEqual(value) => different(value);
 
   Where contains(value) {
     this.value = '%$value%';
@@ -90,9 +94,7 @@ class Where {
   /**
    * Alias of [isIn]. Builds a WHERE IN query.
    */
-  Where inList(List<dynamic> values) {
-    return isIn(values);
-  }
+  Where inList(List<dynamic> values) => isIn(values);
 
   /**
    * Builds a WHERE IN query.
@@ -107,9 +109,7 @@ class Where {
   /**
    * Alias of [notIn]. Builds a WHERE NOT IN query.
    */
-  Where isNotIn(List<dynamic> values) {
-    return notIn(values);
-  }
+  Where isNotIn(List<dynamic> values) => notIn(values);
 
   /**
    * Builds a WHERE NOT IN query.

--- a/tunder/lib/src/exceptions/http_exception.dart
+++ b/tunder/lib/src/exceptions/http_exception.dart
@@ -1,8 +1,8 @@
 class HttpException implements Exception {
-  late int statusCode;
-  late String message;
+  final int statusCode;
+  final String message;
 
-  HttpException({
+  const HttpException({
     required this.statusCode,
     required this.message,
   });

--- a/tunder/lib/src/exceptions/not_found_http_exception.dart
+++ b/tunder/lib/src/exceptions/not_found_http_exception.dart
@@ -2,8 +2,9 @@ import 'package:tunder/http.dart';
 import 'package:tunder/src/exceptions/http_exception.dart';
 
 class NotFoundHttpException extends HttpException {
-  NotFoundHttpException()
+  const NotFoundHttpException()
       : super(
-            statusCode: Response.HTTP_NOT_FOUND,
-            message: 'Resource not found.');
+          statusCode: Response.HTTP_NOT_FOUND,
+          message: 'Resource not found.',
+        );
 }

--- a/tunder/lib/src/exceptions/record_not_found_exception.dart
+++ b/tunder/lib/src/exceptions/record_not_found_exception.dart
@@ -1,5 +1,5 @@
 class RecordNotFoundException implements Exception {
-  RecordNotFoundException();
+  final String message = 'Record not found.';
 
-  final String message = 'Record not found';
+  const RecordNotFoundException();
 }

--- a/tunder/lib/src/exceptions/route_not_found_exception.dart
+++ b/tunder/lib/src/exceptions/route_not_found_exception.dart
@@ -1,5 +1,3 @@
 class RouteNotFoundException extends ArgumentError implements Exception {
-  String message;
-
-  RouteNotFoundException(this.message);
+  RouteNotFoundException(String message) : super(message);
 }

--- a/tunder/lib/src/http/controller.dart
+++ b/tunder/lib/src/http/controller.dart
@@ -1,5 +1,5 @@
 class Controller {
-  const Controller({this.middleware});
-
   final dynamic middleware;
+
+  const Controller({this.middleware});
 }

--- a/tunder/lib/src/http/kernel.dart
+++ b/tunder/lib/src/http/kernel.dart
@@ -39,7 +39,7 @@ class Kernel implements Contract.HttpKernelContract {
       response.statusCode = error.statusCode;
     } catch (e, s) {
       response.statusCode = 500;
-      response.write('Error: $e\n Stack trace:\n$s');
+      response.write('Error: $e\nStack trace:\n$s');
     } finally {
       response.close(request);
     }

--- a/tunder/lib/src/http/request.dart
+++ b/tunder/lib/src/http/request.dart
@@ -40,9 +40,7 @@ class Request {
     return route;
   }
 
-  void setRoute(RouteEntry route) {
-    this.route = route;
-  }
+  void setRoute(RouteEntry route) => this.route = route;
 
   dynamic get(String name) {
     dynamic value = uri.queryParameters[name] ?? null;
@@ -55,7 +53,7 @@ class Request {
 
   getRouteParam(dynamic name, {Type type = String}) {
     if (name is String) name = Symbol(name);
-    if (!(name is Symbol)) throw ArgumentError.value(name, 'name');
+    if (name is! Symbol) throw ArgumentError.value(name, 'name');
 
     return route.paramValue(
       name,
@@ -65,11 +63,11 @@ class Request {
   }
 
   _tryParsePrimitives(String value) {
+    if (value == '') return null;
     if (int.tryParse(value) != null) return int.tryParse(value);
     if (double.tryParse(value) != null) return double.tryParse(value);
     if (value == 'null') return null;
     if (value == 'undefined') return null;
-    if (value == '') return null;
     if (value == 'true') return true;
     if (value == 'false') return false;
 

--- a/tunder/lib/src/http/response.dart
+++ b/tunder/lib/src/http/response.dart
@@ -7,14 +7,12 @@ class Response {
   static const HTTP_NOT_FOUND = 404;
   static const HTTP_METHOD_NOT_ALLOWED = 405;
 
-  late HttpResponse original;
-  late Request request;
+  HttpResponse original;
+  Request request;
   Map<String, String?> headers;
   String? body;
 
-  void set statusCode(statusCode) {
-    original.statusCode = statusCode;
-  }
+  set statusCode(int statusCode) => original.statusCode = statusCode;
 
   Response({
     required this.original,
@@ -30,9 +28,7 @@ class Response {
           original: request.response,
         );
 
-  static Never notFound() {
-    throw NotFoundHttpException();
-  }
+  static Never notFound() => throw NotFoundHttpException();
 
   void write([String? overwrite]) {
     body = overwrite ?? body;

--- a/tunder/lib/src/http/route.dart
+++ b/tunder/lib/src/http/route.dart
@@ -4,51 +4,43 @@ import 'package:tunder/src/http/router.dart';
 import 'package:tunder/utils.dart';
 
 class Route {
-  const Route({this.method, this.methods, this.middleware});
-
   final String? method;
   final List<String>? methods;
   final dynamic middleware;
+
+  const Route({this.method, this.methods, this.middleware});
+
   static Router get router => app(Router);
 
-  static RouteEntry delete(String path, handler, [String? action]) {
-    return router.delete(path, handler, action);
-  }
+  static RouteEntry get(String path, handler, [String? action]) =>
+      router.get(path, handler, action);
 
-  static RouteEntry get(String path, handler, [String? action]) {
-    return router.get(path, handler, action);
-  }
+  static RouteEntry post(String path, handler, [String? action]) =>
+      router.post(path, handler, action);
 
-  static RouteEntry patch(String path, handler, [String? action]) {
-    return router.patch(path, handler, action);
-  }
+  static RouteEntry put(String path, handler, [String? action]) =>
+      router.put(path, handler, action);
 
-  static RouteEntry post(String path, handler, [String? action]) {
-    return router.post(path, handler, action);
-  }
+  static RouteEntry delete(String path, handler, [String? action]) =>
+      router.delete(path, handler, action);
 
-  static RouteEntry put(String path, handler, [String? action]) {
-    return router.put(path, handler, action);
-  }
+  static RouteEntry patch(String path, handler, [String? action]) =>
+      router.patch(path, handler, action);
 
-  static void group(RouteOptions options, Function registrar) {
-    return router.group(options, registrar);
-  }
+  static void group(RouteOptions options, Function registrar) =>
+      router.group(options, registrar);
 
-  static RouteEntry prefix(String prefix) {
-    return router.prefix(prefix);
-  }
+  static RouteEntry prefix(String prefix) => router.prefix(prefix);
 
-  static void discovery(Type controller) {
-    return router.discovery(controller);
-  }
+  static void discovery(Type controller) => router.discovery(controller);
 
-  static RouteEntry middlewares(middlewares) {
-    return router.middleware(middlewares);
-  }
+  static RouteEntry middlewares(middlewares) => router.middleware(middlewares);
 
-  static RouteEntry via(List<String> methods, String uri, handler,
-      [String? action]) {
-    return router.via(methods, uri, handler, action);
-  }
+  static RouteEntry via(
+    List<String> methods,
+    String uri,
+    handler, [
+    String? action,
+  ]) =>
+      router.via(methods, uri, handler, action);
 }

--- a/tunder/lib/src/http/route_definitions.dart
+++ b/tunder/lib/src/http/route_definitions.dart
@@ -2,8 +2,8 @@ import 'package:tunder/src/http/route_entry.dart';
 
 abstract class RouteDefinitions {
   RouteEntry get(String path, handler, [String? action]);
-  RouteEntry put(String path, handler, [String? action]);
-  RouteEntry patch(String path, handler, [String? action]);
   RouteEntry post(String path, handler, [String? action]);
+  RouteEntry put(String path, handler, [String? action]);
   RouteEntry delete(String path, handler, [String? action]);
+  RouteEntry patch(String path, handler, [String? action]);
 }

--- a/tunder/lib/src/http/route_entry.dart
+++ b/tunder/lib/src/http/route_entry.dart
@@ -8,29 +8,29 @@ import 'package:tunder/utils.dart';
 import 'package:tunder/tunder.dart';
 
 class RouteEntry implements RouteDefinitions {
-  late String path;
-  late List<String> methods;
-  late dynamic handler;
-  late Container container;
-  late Router router;
+  String path;
+  List<String> methods;
+  dynamic handler;
+  Container container;
+  Router router;
   RouteOptions? options;
 
   String? _name;
   String? action;
   List middlewares = [];
 
-  static const GET = 'GET';
   static const HEAD = 'HEAD';
-  static const PUT = 'PUT';
-  static const PATCH = 'PATCH';
+  static const GET = 'GET';
   static const POST = 'POST';
+  static const PUT = 'PUT';
   static const DELETE = 'DELETE';
+  static const PATCH = 'PATCH';
 
   Uri get uri => Uri.parse(url(path));
 
   RouteEntry({
-    required this.methods,
     required this.path,
+    required this.methods,
     required this.handler,
     required this.container,
     required this.router,
@@ -38,9 +38,7 @@ class RouteEntry implements RouteDefinitions {
     this.options,
   });
 
-  List<String> get parameters {
-    return uri.pathSegments.where(_isParameter).toList();
-  }
+  List<String> get parameters => uri.pathSegments.where(_isParameter).toList();
 
   RouteEntry name(String name) {
     _name = _name != null ? '$_name$name' : name;
@@ -49,13 +47,9 @@ class RouteEntry implements RouteDefinitions {
     return this;
   }
 
-  RouteEntry prefix(String prefix) {
-    return setOption(prefix: prefix);
-  }
+  RouteEntry prefix(String prefix) => setOption(prefix: prefix);
 
-  void group(routes) {
-    router.group(options ?? RouteOptions(), routes);
-  }
+  void group(routes) => router.group(options ?? RouteOptions(), routes);
 
   RouteEntry middleware(middleware) {
     setOption(middleware: middleware);
@@ -124,11 +118,10 @@ class RouteEntry implements RouteDefinitions {
     });
   }
 
-  Controller? _getAnnotationController(ClassMirror controller) {
-    return controller.metadata
-        .firstWhereOrNull((m) => m.reflectee is Controller)
-        ?.reflectee;
-  }
+  Controller? _getAnnotationController(ClassMirror controller) =>
+      controller.metadata
+          .firstWhereOrNull((m) => m.reflectee is Controller)
+          ?.reflectee;
 
   void _registerRoutesForMethods(
     List<MapEntry<Symbol, DeclarationMirror>> methods,
@@ -210,19 +203,14 @@ class RouteEntry implements RouteDefinitions {
     return metadata.methods ?? defaultVerbs;
   }
 
-  Route? _getAnnotationRouteFromMethod(DeclarationMirror method) {
-    return method.metadata
-        .firstWhereOrNull((m) => m.reflectee is Route)
-        ?.reflectee;
-  }
+  Route? _getAnnotationRouteFromMethod(DeclarationMirror method) =>
+      method.metadata.firstWhereOrNull((m) => m.reflectee is Route)?.reflectee;
 
-  String _getRoutePathFromSymbol(Symbol symbol) {
-    return MirrorSystem.getName(symbol).paramCase;
-  }
+  String _getRoutePathFromSymbol(Symbol symbol) =>
+      MirrorSystem.getName(symbol).paramCase;
 
-  String _getResourcePathFromControllerName(Symbol name) {
-    return MirrorSystem.getName(name).paramCase.replaceAll('-controller', '');
-  }
+  String _getResourcePathFromControllerName(Symbol name) =>
+      MirrorSystem.getName(name).paramCase.replaceAll('-controller', '');
 
   RouteEntry _registerRoute(
     List<String> methods,
@@ -231,36 +219,28 @@ class RouteEntry implements RouteDefinitions {
     String action,
     String resource,
     dynamic middleware,
-  ) {
-    return router
-        .via(methods, path, controller, action)
-        .middleware(middleware)
-        .name('$resource.${action.paramCase}');
-  }
+  ) =>
+      router
+          .via(methods, path, controller, action)
+          .middleware(middleware)
+          .name('$resource.${action.paramCase}');
 
-  RouteEntry get(String path, handler, [String? action]) {
-    return _set(path, handler, action)..register();
-  }
+  RouteEntry get(String path, handler, [String? action]) =>
+      _set(path, handler, action)..register();
 
-  RouteEntry delete(String path, handler, [String? action]) {
-    return _set(path, handler, action)..register();
-  }
+  RouteEntry post(String path, handler, [String? action]) =>
+      _set(path, handler, action)..register();
 
-  RouteEntry patch(String path, handler, [String? action]) {
-    return _set(path, handler, action)..register();
-  }
+  RouteEntry put(String path, handler, [String? action]) =>
+      _set(path, handler, action)..register();
 
-  RouteEntry post(String path, handler, [String? action]) {
-    return _set(path, handler, action)..register();
-  }
+  RouteEntry delete(String path, handler, [String? action]) =>
+      _set(path, handler, action)..register();
 
-  RouteEntry put(String path, handler, [String? action]) {
-    return _set(path, handler, action)..register();
-  }
+  RouteEntry patch(String path, handler, [String? action]) =>
+      _set(path, handler, action)..register();
 
-  void register() {
-    router.register(this);
-  }
+  void register() => router.register(this);
 
   RouteEntry mergeOptions(RouteOptions parentOptions) {
     options = options ?? RouteOptions();
@@ -287,9 +267,7 @@ class RouteEntry implements RouteDefinitions {
     return this;
   }
 
-  bool nameIs(String name) {
-    return _name == name;
-  }
+  bool nameIs(String name) => _name == name;
 
   bool matches(Request request) {
     if (!methods.contains(request.method)) return false;
@@ -306,9 +284,8 @@ class RouteEntry implements RouteDefinitions {
     });
   }
 
-  String sanitize(String string) {
-    return string.replaceAll(RegExp(r'^/*'), '').replaceAll(RegExp(r'/*$'), '');
-  }
+  String sanitize(String string) =>
+      string.replaceAll(RegExp(r'^/*'), '').replaceAll(RegExp(r'/*$'), '');
 
   run(Request request) async {
     request.setRoute(this);
@@ -352,40 +329,36 @@ class RouteEntry implements RouteDefinitions {
   _injectedParams(InstanceMirror controller, String action, Request request) {
     MethodMirror? method = _getMethodFrom(controller, action);
 
-    if (method == null) return [];
+    return method == null
+        ? []
+        : method.parameters.map((param) {
+            var type = param.type.reflectedType;
+            if (type == Request) return request;
+            if (_isPrimitive(type)) {
+              return paramValue(
+                param.simpleName,
+                request: request,
+                castTo: type,
+              );
+            }
 
-    return method.parameters.map((param) {
-      var type = param.type.reflectedType;
-      if (type == Request) return request;
-      if (_isPrimitive(type)) {
-        return paramValue(
-          param.simpleName,
-          request: request,
-          castTo: type,
-        );
-      }
-
-      return container.get(param.type.reflectedType);
-    }).toList();
+            return container.get(param.type.reflectedType);
+          }).toList();
   }
 
-  bool _isPrimitive(type) {
-    return [int, double, String].contains(type);
-  }
+  bool _isPrimitive(type) => const [int, double, String].contains(type);
 
-  MethodMirror? _getMethodFrom(InstanceMirror instance, String methodName) {
-    return _getMethodsFrom(instance)
-        .where((element) => element.key == Symbol(methodName))
-        .toList()
-        .firstOrNull
-        ?.value as MethodMirror?;
-  }
+  MethodMirror? _getMethodFrom(InstanceMirror instance, String methodName) =>
+      _getMethodsFrom(instance)
+          .where((element) => element.key == Symbol(methodName))
+          .toList()
+          .firstOrNull
+          ?.value as MethodMirror?;
 
   Iterable<MapEntry<Symbol, DeclarationMirror>> _getMethodsFrom(
-      InstanceMirror instance) {
-    return instance.type.declarations.entries.where((declaration) =>
-        declaration.value is MethodMirror && !declaration.value.isPrivate);
-  }
+          InstanceMirror instance) =>
+      instance.type.declarations.entries.where((declaration) =>
+          declaration.value is MethodMirror && !declaration.value.isPrivate);
 
   bool hasController() {
     var controller = reflectClass(handler);
@@ -449,29 +422,23 @@ class RouteEntry implements RouteDefinitions {
         }).join('/');
   }
 
-  bool _allowedParamTypes(params) {
-    return [int, double, String].any((type) => params.runtimeType == type) ||
-        params is List ||
-        params is Map;
-  }
+  bool _allowedParamTypes(params) =>
+      const [int, double, String].any((type) => params.runtimeType == type) ||
+      params is List ||
+      params is Map;
 
-  int _paramIndexByName(Symbol paramName) {
-    return uri.pathSegments.indexOf(_paramByName(paramName));
-  }
+  int _paramIndexByName(Symbol paramName) =>
+      uri.pathSegments.indexOf(_paramByName(paramName));
 
-  String _paramByName(Symbol paramName) {
-    return parameters.firstWhere(
-      (segment) => Symbol(_removeCurlyBraces(segment)) == paramName,
-    );
-  }
+  String _paramByName(Symbol paramName) => parameters.firstWhere(
+        (segment) => Symbol(_removeCurlyBraces(segment)) == paramName,
+      );
 
-  bool _isParameter(String segment) {
-    return segment.startsWith('{') && segment.endsWith('}');
-  }
+  bool _isParameter(String segment) =>
+      segment.startsWith('{') && segment.endsWith('}');
 
-  String _removeCurlyBraces(String segment) {
-    return segment.replaceAll(RegExp(r'[{}]*'), '');
-  }
+  String _removeCurlyBraces(String segment) =>
+      segment.replaceAll(RegExp(r'[{}]*'), '');
 
   RouteEntry _set(String path, handler, String? action) {
     _setPath(path);
@@ -500,17 +467,12 @@ class RouteEntry implements RouteDefinitions {
     return this;
   }
 
-  _getOption(option) {
-    if (options == null) return;
+  _getOption(option) => options == null
+      ? null
+      : reflect(options).getField(Symbol(option)).reflectee;
 
-    return reflect(options).getField(Symbol(option)).reflectee;
-  }
-
-  RouteEntry _setPath(String path) {
+  _setPath(String path) {
     String? prefix = _getOption('prefix');
-
     this.path = prefix != null ? "${sanitize(prefix)}/${sanitize(path)}" : path;
-
-    return this;
   }
 }

--- a/tunder/lib/src/http/route_entry.dart
+++ b/tunder/lib/src/http/route_entry.dart
@@ -329,21 +329,19 @@ class RouteEntry implements RouteDefinitions {
   _injectedParams(InstanceMirror controller, String action, Request request) {
     MethodMirror? method = _getMethodFrom(controller, action);
 
-    return method == null
-        ? []
-        : method.parameters.map((param) {
-            var type = param.type.reflectedType;
-            if (type == Request) return request;
-            if (_isPrimitive(type)) {
-              return paramValue(
-                param.simpleName,
-                request: request,
-                castTo: type,
-              );
-            }
+    if (method == null) return [];
 
-            return container.get(param.type.reflectedType);
-          }).toList();
+    return method.parameters.map((param) {
+      var type = param.type.reflectedType;
+
+      if (type == Request) {
+        return request;
+      } else if (_isPrimitive(type)) {
+        return paramValue(param.simpleName, request: request, castTo: type);
+      } else {
+        return container.get(param.type.reflectedType);
+      }
+    }).toList();
   }
 
   bool _isPrimitive(type) => const [int, double, String].contains(type);
@@ -422,10 +420,11 @@ class RouteEntry implements RouteDefinitions {
         }).join('/');
   }
 
-  bool _allowedParamTypes(params) =>
-      const [int, double, String].any((type) => params.runtimeType == type) ||
-      params is List ||
-      params is Map;
+  bool _allowedParamTypes(params) {
+    return [int, double, String].any((type) => params.runtimeType == type) ||
+        params is List ||
+        params is Map;
+  }
 
   int _paramIndexByName(Symbol paramName) =>
       uri.pathSegments.indexOf(_paramByName(paramName));

--- a/tunder/lib/src/http/route_entry.dart
+++ b/tunder/lib/src/http/route_entry.dart
@@ -334,24 +334,29 @@ class RouteEntry implements RouteDefinitions {
     return method.parameters.map((param) {
       var type = param.type.reflectedType;
 
-      if (type == Request) {
-        return request;
-      } else if (_isPrimitive(type)) {
-        return paramValue(param.simpleName, request: request, castTo: type);
-      } else {
-        return container.get(param.type.reflectedType);
+      if (type == Request) return request;
+
+      if (_isPrimitive(type)) {
+        return paramValue(
+          param.simpleName,
+          request: request,
+          castTo: type,
+        );
       }
+
+      return container.get(param.type.reflectedType);
     }).toList();
   }
 
   bool _isPrimitive(type) => const [int, double, String].contains(type);
 
-  MethodMirror? _getMethodFrom(InstanceMirror instance, String methodName) =>
-      _getMethodsFrom(instance)
-          .where((element) => element.key == Symbol(methodName))
-          .toList()
-          .firstOrNull
-          ?.value as MethodMirror?;
+  MethodMirror? _getMethodFrom(InstanceMirror instance, String methodName) {
+    return _getMethodsFrom(instance)
+        .where((element) => element.key == Symbol(methodName))
+        .toList()
+        .firstOrNull
+        ?.value as MethodMirror?;
+  }
 
   Iterable<MapEntry<Symbol, DeclarationMirror>> _getMethodsFrom(
           InstanceMirror instance) =>

--- a/tunder/lib/src/http/router.dart
+++ b/tunder/lib/src/http/router.dart
@@ -9,7 +9,7 @@ import 'package:tunder/src/http/route_definitions.dart';
 import 'package:tunder/src/http/route_options.dart';
 
 class Router implements RouteDefinitions {
-  late Application app;
+  Application app;
   List middlewares = [];
   Map<String, Type> aliasMiddleware = {};
   final List<RouteEntry> routes = [];
@@ -17,63 +17,48 @@ class Router implements RouteDefinitions {
 
   Router(this.app);
 
-  RouteEntry prefix(String prefix) {
-    return _newRoute([RouteEntry.GET, RouteEntry.HEAD], prefix, () => null)
-        .setOption(
-      prefix: prefix,
-    );
-  }
+  RouteEntry prefix(String prefix) =>
+      _newRoute([RouteEntry.GET, RouteEntry.HEAD], prefix, () => null)
+          .setOption(prefix: prefix);
 
-  void discovery(Type controller) {
-    return _newRoute([RouteEntry.GET], '', () => null).discovery(controller);
-  }
+  void discovery(Type controller) =>
+      _newRoute([RouteEntry.GET], '', () => null).discovery(controller);
 
-  RouteEntry middleware(middlewares) {
-    return _newRoute([RouteEntry.GET, RouteEntry.HEAD], '', () => null)
-        .setOption(
-      middleware: middlewares,
-    );
-  }
+  RouteEntry middleware(middlewares) =>
+      _newRoute([RouteEntry.GET, RouteEntry.HEAD], '', () => null)
+          .setOption(middleware: middlewares);
 
-  RouteEntry via(List<String> methods, String uri, handler, [String? action]) {
-    return _addRoute(methods, uri, handler, action);
-  }
+  RouteEntry via(List<String> methods, String uri, handler, [String? action]) =>
+      _addRoute(methods, uri, handler, action);
 
-  RouteEntry get(String uri, handler, [String? action]) {
-    return _addRoute([RouteEntry.GET, RouteEntry.HEAD], uri, handler, action);
-  }
+  RouteEntry get(String uri, handler, [String? action]) =>
+      _addRoute([RouteEntry.GET, RouteEntry.HEAD], uri, handler, action);
 
-  RouteEntry put(String uri, handler, [String? action]) {
-    return _addRoute([RouteEntry.PUT], uri, handler, action);
-  }
+  RouteEntry post(String uri, handler, [String? action]) =>
+      _addRoute([RouteEntry.POST], uri, handler, action);
 
-  RouteEntry patch(String uri, handler, [String? action]) {
-    return _addRoute([RouteEntry.PATCH], uri, handler, action);
-  }
+  RouteEntry put(String uri, handler, [String? action]) =>
+      _addRoute([RouteEntry.PUT], uri, handler, action);
 
-  RouteEntry post(String uri, handler, [String? action]) {
-    return _addRoute([RouteEntry.POST], uri, handler, action);
-  }
+  RouteEntry delete(String uri, handler, [String? action]) =>
+      _addRoute([RouteEntry.DELETE], uri, handler, action);
 
-  RouteEntry delete(String uri, handler, [String? action]) {
-    return _addRoute([RouteEntry.DELETE], uri, handler, action);
-  }
+  RouteEntry patch(String uri, handler, [String? action]) =>
+      _addRoute([RouteEntry.PATCH], uri, handler, action);
 
   RouteEntry _addRoute(List<String> methods, String path, handler,
-      [String? action]) {
-    return _newRoute(methods, path, handler, action)..register();
-  }
+          [String? action]) =>
+      _newRoute(methods, path, handler, action)..register();
 
-  RouteEntry _newRoute(List<String> methods, path, handler, [String? action]) {
-    return RouteEntry(
-      methods: methods,
-      path: path,
-      handler: handler,
-      action: action,
-      container: app,
-      router: this,
-    );
-  }
+  RouteEntry _newRoute(List<String> methods, path, handler, [String? action]) =>
+      RouteEntry(
+        methods: methods,
+        path: path,
+        handler: handler,
+        action: action,
+        container: app,
+        router: this,
+      );
 
   void group(RouteOptions options, Function registrar) {
     // add the group attributes to stack
@@ -90,14 +75,12 @@ class Router implements RouteDefinitions {
     routes.add(route);
   }
 
-  FutureOr runRoute(Request request, RouteEntry route) {
-    return Pipeline(app)
-        .send(request)
-        .through(_gatherMiddlewares(route))
-        .then((request) async {
-      return toResponse(request, await route.run(request));
-    });
-  }
+  FutureOr runRoute(Request request, RouteEntry route) => Pipeline(app)
+          .send(request)
+          .through(_gatherMiddlewares(route))
+          .then((request) async {
+        return toResponse(request, await route.run(request));
+      });
 
   Response toResponse(Request request, dynamicResponse) {
     Response response = Response.from(request);
@@ -128,9 +111,6 @@ class Router implements RouteDefinitions {
     return _resolveMiddlewares(currentMiddlewares.toSet().toList());
   }
 
-  List _resolveMiddlewares(List middlewares) {
-    return middlewares
-        .map((m) => m is String ? aliasMiddleware[m] : m)
-        .toList();
-  }
+  List _resolveMiddlewares(List middlewares) =>
+      middlewares.map((m) => m is String ? aliasMiddleware[m] : m).toList();
 }

--- a/tunder/lib/src/providers/database_service_provider.dart
+++ b/tunder/lib/src/providers/database_service_provider.dart
@@ -8,11 +8,11 @@ class DatabaseServiceProvider extends ServiceProvider {
     app.bind(
       DatabaseConnection,
       (_) => PostgresConnection(
-        host: env('DB_HOST') ?? "localhost",
+        host: env('DB_HOST') ?? 'localhost',
         port: int.parse(env('DB_PORT') ?? '5432'),
-        database: env('DB_DATABASE') ?? "tunder_test",
-        username: env('DB_USERNAME') ?? "postgres",
-        password: env('DB_PASSWORD') ?? "docker",
+        database: env('DB_DATABASE') ?? 'tunder_test',
+        username: env('DB_USERNAME') ?? 'postgres',
+        password: env('DB_PASSWORD') ?? 'docker',
       ),
     );
   }

--- a/tunder/lib/src/utils/random.dart
+++ b/tunder/lib/src/utils/random.dart
@@ -4,8 +4,8 @@ class Generate {
   static String id([int length = 16]) {
     const characters =
         '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
     var random = Random.secure();
+
     return String.fromCharCodes(
       Iterable.generate(
         length,
@@ -15,9 +15,9 @@ class Generate {
   }
 
   static String password([int length = 32]) {
-    var random = Random.secure();
     const characters =
-        '!@#\$%^&*()-_=+0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        r'!@#\$%^&*()-_=+0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    var random = Random.secure();
 
     return String.fromCharCodes(
       Iterable.generate(

--- a/tunder/lib/tunder.dart
+++ b/tunder/lib/tunder.dart
@@ -4,4 +4,4 @@ export 'src/exceptions/exceptions.dart';
 
 export '_common.dart';
 
-const TunderVersion = '1.0.0';
+const tunderVersion = '1.0.0';

--- a/tunder/pubspec.yaml
+++ b/tunder/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tunder is a framework designed to build server side applications.
 version: 0.1.0
 repository: https://github.com/tunder-team/tunder
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 dependencies:
   path: ^1.8.1
   http: ^0.13.4

--- a/tunder/test/core/application_test.dart
+++ b/tunder/test/core/application_test.dart
@@ -9,13 +9,9 @@ import 'package:tunder/tunder.dart';
 class A {
   A();
 
-  factory A.from() {
-    return A();
-  }
+  factory A.from() => A();
 
-  someMethod() {
-    return 'some method called';
-  }
+  someMethod() => 'some method called';
 }
 
 class B {
@@ -230,7 +226,5 @@ main() {
 
 class MyServiceProvider extends ServiceProvider {
   @override
-  boot(Application app) {
-    app.bind('my.service', 'it worked');
-  }
+  boot(Application app) => app.bind('my.service', 'it worked');
 }

--- a/tunder/test/core/container_test.dart
+++ b/tunder/test/core/container_test.dart
@@ -2,9 +2,7 @@ import 'package:tunder/src/core/container.dart';
 import 'package:test/test.dart';
 
 class A {
-  name() {
-    return 'A';
-  }
+  name() => 'A';
 }
 
 void main() {

--- a/tunder/test/core/server_test.dart
+++ b/tunder/test/core/server_test.dart
@@ -38,9 +38,8 @@ main() {
   });
 }
 
-createServer() async {
-  return await HttpServer.bind(InternetAddress.loopbackIPv4, 9123);
-}
+createServer() async =>
+    await HttpServer.bind(InternetAddress.loopbackIPv4, 9123);
 
 handleRequest(HttpServer server) async {
   await for (var request in server) {

--- a/tunder/test/database/db_test.dart
+++ b/tunder/test/database/db_test.dart
@@ -119,5 +119,5 @@ main() {
 class SomeException implements Exception {
   final String message;
 
-  SomeException(this.message);
+  const SomeException(this.message);
 }

--- a/tunder/test/database/postgres_connection_test.dart
+++ b/tunder/test/database/postgres_connection_test.dart
@@ -156,5 +156,5 @@ main() {
 class SomeException implements Exception {
   final String message;
 
-  SomeException(this.message);
+  const SomeException(this.message);
 }

--- a/tunder/test/extensions/list_test.dart
+++ b/tunder/test/extensions/list_test.dart
@@ -27,5 +27,6 @@ main() {
 
 class User {
   int id;
+
   User(this.id);
 }

--- a/tunder/test/helpers.dart
+++ b/tunder/test/helpers.dart
@@ -1,22 +1,55 @@
 import 'package:http/http.dart' as http;
 import 'package:tunder/utils.dart';
 
-Future<http.Response> get(String uri, {headers}) {
-  return http.get(Uri.parse(url(uri)), headers: headers);
-}
+Future<http.Response> get(
+  String uri, {
+  headers,
+}) =>
+    http.get(
+      Uri.parse(url(uri)),
+      headers: headers,
+    );
 
-Future<http.Response> put(String uri, {headers, body}) {
-  return http.put(Uri.parse(url(uri)), headers: headers, body: body);
-}
+Future<http.Response> post(
+  String uri, {
+  headers,
+  body,
+}) =>
+    http.post(
+      Uri.parse(url(uri)),
+      headers: headers,
+      body: body,
+    );
 
-Future<http.Response> patch(String uri, {headers, body}) {
-  return http.patch(Uri.parse(url(uri)), headers: headers, body: body);
-}
+Future<http.Response> put(
+  String uri, {
+  headers,
+  body,
+}) =>
+    http.put(
+      Uri.parse(url(uri)),
+      headers: headers,
+      body: body,
+    );
 
-Future<http.Response> post(String uri, {headers, body}) {
-  return http.post(Uri.parse(url(uri)), headers: headers, body: body);
-}
+Future<http.Response> delete(
+  String uri, {
+  headers,
+  body,
+}) =>
+    http.delete(
+      Uri.parse(url(uri)),
+      headers: headers,
+      body: body,
+    );
 
-Future<http.Response> delete(String uri, {headers, body}) {
-  return http.delete(Uri.parse(url(uri)), headers: headers, body: body);
-}
+Future<http.Response> patch(
+  String uri, {
+  headers,
+  body,
+}) =>
+    http.patch(
+      Uri.parse(url(uri)),
+      headers: headers,
+      body: body,
+    );

--- a/tunder/test/http/kernel_test.dart
+++ b/tunder/test/http/kernel_test.dart
@@ -25,7 +25,7 @@ main() {
 class SomeException implements Exception {
   final String message;
 
-  SomeException(this.message);
+  const SomeException(this.message);
 
   @override
   String toString() => message;

--- a/tunder/test/http/middlewares/middleware_test.dart
+++ b/tunder/test/http/middlewares/middleware_test.dart
@@ -77,7 +77,5 @@ main() {
 }
 
 class AlwaysNotFound implements Middleware {
-  handle(request, next) {
-    return Response.notFound();
-  }
+  handle(request, next) => Response.notFound();
 }

--- a/tunder/test/http/router/dependency_injection_test.dart
+++ b/tunder/test/http/router/dependency_injection_test.dart
@@ -24,13 +24,9 @@ main() {
 }
 
 class UserController extends Controller {
-  index(Request request, SomeService service) {
-    return service.doSomething();
-  }
+  index(Request request, SomeService service) => service.doSomething();
 }
 
 class SomeService {
-  doSomething() {
-    return 'doSomething worked';
-  }
+  doSomething() => 'doSomething worked';
 }

--- a/tunder/test/http/router/discovery_test.dart
+++ b/tunder/test/http/router/discovery_test.dart
@@ -159,66 +159,39 @@ main() {
 }
 
 class TunderUserController extends Controller {
-  index() {
-    return 'index worked';
-  }
+  index() => 'index worked';
 
-  show(int id) {
-    return 'show worked $id';
-  }
+  show(int id) => 'show worked $id';
 
-  create() {
-    return 'create worked';
-  }
+  create() => 'create worked';
 
-  store() {
-    return 'store worked';
-  }
+  store() => 'store worked';
 
-  update(int id) {
-    return 'update worked $id';
-  }
+  update(int id) => 'update worked $id';
 
-  delete(int id) {
-    return 'delete worked $id';
-  }
+  delete(int id) => 'delete worked $id';
 
-  forceDelete(int id) {
-    return 'forceDelete worked $id';
-  }
+  forceDelete(int id) => 'forceDelete worked $id';
 
-  getAction() {
-    return 'getAction worked';
-  }
+  getAction() => 'getAction worked';
 
   @Route(method: 'post')
-  postAction() {
-    return 'postAction worked';
-  }
+  postAction() => 'postAction worked';
 
   @Route(method: 'put')
-  putAction(Request request, int id, String name) {
-    return 'putAction worked $id $name';
-  }
+  putAction(Request request, int id, String name) =>
+      'putAction worked $id $name';
 
   @Route(method: 'patch')
-  patchAction(int id) {
-    return 'patchAction worked $id';
-  }
+  patchAction(int id) => 'patchAction worked $id';
 
   @Route(method: 'delete')
-  deleteAction(int id) {
-    return 'deleteAction worked $id';
-  }
+  deleteAction(int id) => 'deleteAction worked $id';
 
   // ignore: unused_element
-  _somePrivateMethod() {
-    return 'should not generate route';
-  }
+  _somePrivateMethod() => 'should not generate route';
 }
 
 class PartialController extends Controller {
-  index() {
-    return 'index worked';
-  }
+  index() => 'index worked';
 }

--- a/tunder/test/http/router/group_test.dart
+++ b/tunder/test/http/router/group_test.dart
@@ -46,9 +46,7 @@ main() {
 }
 
 class TestController extends Controller {
-  index() {
-    return 'index worked';
-  }
+  index() => 'index worked';
 }
 
 class MyMiddleware extends Middleware {

--- a/tunder/test/http/router/http_verbs_test.dart
+++ b/tunder/test/http/router/http_verbs_test.dart
@@ -40,7 +40,5 @@ main() {
 }
 
 class TestController extends Controller {
-  index() {
-    return 'index worked';
-  }
+  index() => 'index worked';
 }

--- a/tunder/test/http/router/middleware_annotations_test.dart
+++ b/tunder/test/http/router/middleware_annotations_test.dart
@@ -46,7 +46,5 @@ class MyClassMiddleware extends Middleware {
 @Controller(middleware: MyClassMiddleware)
 class ExampleController extends Controller {
   @Route(method: 'post', middleware: MyMiddleware)
-  someAction() {
-    return 'someAction worked';
-  }
+  someAction() => 'someAction worked';
 }

--- a/tunder/test/http/router/prefix_test.dart
+++ b/tunder/test/http/router/prefix_test.dart
@@ -21,7 +21,5 @@ main() {
 }
 
 class TestController extends Controller {
-  index() {
-    return 'index worked';
-  }
+  index() => 'index worked';
 }

--- a/tunder/test/http/router/routing_test.dart
+++ b/tunder/test/http/router/routing_test.dart
@@ -122,27 +122,18 @@ main() {
 }
 
 class TestController extends Controller {
-  index() {
-    return 'TestController worked';
-  }
+  index() => 'TestController worked';
 
-  methodWithDependencies(Request request, Router router) {
-    return 'TestController worked with dependencies';
-  }
+  methodWithDependencies(Request request, Router router) =>
+      'TestController worked with dependencies';
 }
 
 class UserController extends Controller {
-  show(Request request, int user) {
-    return 'User id is $user.';
-  }
+  show(Request request, int user) => 'User id is $user.';
 
-  index(Request request, SomeService service) {
-    return service.doSomething();
-  }
+  index(Request request, SomeService service) => service.doSomething();
 }
 
 class SomeService {
-  doSomething() {
-    return 'doSomething worked';
-  }
+  doSomething() => 'doSomething worked';
 }


### PR DESCRIPTION
Most functions that had a single line were refactored to the arrow notation.

![example](https://user-images.githubusercontent.com/14764307/182673438-21630ad5-fe4d-4303-80a0-30c90019be82.png)

The backslash in the password generator characters was being treated as an escape character. I've changed the characters to be a raw string.

![image](https://user-images.githubusercontent.com/14764307/182567815-b6f77e37-5315-4a53-870f-f442b4472e5f.png)
