### PR TITLE
feat: allow defining the server host without an .env file

### DIFF
--- a/tunder/lib/src/core/application.dart
+++ b/tunder/lib/src/core/application.dart
@@ -21,9 +21,13 @@ class Application extends Container {
 
   static Application create() => Application._();
 
-  Future<HttpServer> serve({int port = 8080, DotEnv? dotenv}) async {
+  Future<HttpServer> serve({
+    String host = 'localhost',
+    int port = 8080,
+    DotEnv? dotenv,
+  }) async {
     dotenv ??= DotEnv()..load(['.env']);
-    final uri = Uri.parse(dotenv['APP_URL'] ?? 'http://localhost:$port');
+    final uri = Uri.parse(dotenv['APP_URL'] ?? 'http://$host:$port');
 
     await server?.close(force: true);
 


### PR DESCRIPTION
Heroku needs to bind on `0.0.0.0` instead of `localhost`. I'm proposing this change to the API.